### PR TITLE
Support for java.nio.file.Path

### DIFF
--- a/src/main/java/de/zedlitz/opendocument/Document.java
+++ b/src/main/java/de/zedlitz/opendocument/Document.java
@@ -7,6 +7,7 @@ import javax.xml.stream.XMLStreamReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
@@ -39,6 +40,10 @@ public class Document {
 
     public Document(final File file) throws XMLStreamException, IOException {
         this(new ZipFile(file));
+    }
+
+    public Document(final Path path) throws XMLStreamException, IOException {
+        this(new ZipFile(path.toFile()));
     }
 
     public Document(final ZipFile file) throws XMLStreamException, IOException {

--- a/src/test/java/de/zedlitz/opendocument/DocumentTest.java
+++ b/src/test/java/de/zedlitz/opendocument/DocumentTest.java
@@ -7,6 +7,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.zip.ZipFile;
@@ -161,6 +163,14 @@ public class DocumentTest extends AbstractBaseTest {
     public void constructor_file() throws XMLStreamException, IOException {
         File file = new File(Objects.requireNonNull(getClass().getResource("/test01.ods")).getFile());
         final Document doc = new Document(file);
+        final Table table1 = doc.nextTable();
+        assertNotNull(table1, "1st table exits");
+    }
+
+    @Test
+    public void constructor_path() throws XMLStreamException, IOException {
+        Path path = Paths.get(Objects.requireNonNull(getClass().getResource("/test01.ods")).getFile());
+        final Document doc = new Document(path);
         final Table table1 = doc.nextTable();
         assertNotNull(table1, "1st table exits");
     }


### PR DESCRIPTION
New constructor `Document(Path)` allows applications using NIO to use `Document` without explicit type conversion to `File`

If *eventually* OpenJDK replaces the **native** `ZipFile` implementation by a **Java-based** implementation, ODS Reader can internally switch from `Path.toFile()` to `Files.newInputStream(path)` *without forcing applications* to change their calling code.